### PR TITLE
setup.py: Set long_description from README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
+import os
 from setuptools import setup, find_packages
+
+long_description = open(
+    os.path.join(
+        os.path.dirname(__file__),
+        'README.rst'
+    )
+).read()
 
 
 setup(
@@ -8,6 +16,7 @@ setup(
     version='0.3',
     url='https://github.com/jonathanslenders/ptpython',
     description='Python REPL build on top of prompt_toolkit',
+    long_description=long_description,
     packages=find_packages('.'),
     install_requires = [
         'prompt_toolkit==0.28',


### PR DESCRIPTION
```
[marca@marca-mac2 ptpython]$ python setup.py egg_info
...
writing ptpython.egg-info/PKG-INFO
...
[marca@marca-mac2 ptpython]$ cat ptpython.egg-info/PKG-INFO
Metadata-Version: 1.0
Name: ptpython
Version: 0.3
Summary: Python REPL build on top of prompt_toolkit
Home-page: https://github.com/jonathanslenders/ptpython
Author: Jonathan Slenders
Author-email: UNKNOWN
License: UNKNOWN
Description: ptpython: a better Python REPL
        ==============================

        ``ptpython`` is an advanced Python REPL built on top of the `prompt_toolkit
        <http://github.com/jonathanslenders/python-prompt-toolkit>`_ library.
...
```