### PR TITLE
fix when startup files not yet exists

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -98,9 +98,13 @@ class PythonRepl(PythonCommandLineInterface):
         """
         if startup_paths:
             for path in startup_paths:
-                with open(path, 'r') as f:
-                    code = compile(f.read(), path, 'exec')
-                    exec_(code, self.get_globals(), self.get_locals())
+                if os.path.exists(path):
+                    with open(path, 'r') as f:
+                        code = compile(f.read(), path, 'exec')
+                        exec_(code, self.get_globals(), self.get_locals())
+                else:
+                    stdout = self.cli.stdout
+                    stdout.write('WARNING | File not found: {}\n\n'.format(path))
 
     def _execute(self, line):
         """


### PR DESCRIPTION
```python
$ ptpython
Traceback (most recent call last):
  File "/usr/local/bin/ptpython", line 9, in <module>
    load_entry_point('ptpython==0.3', 'console_scripts', 'ptpython')()
  File "/Library/Python/2.7/site-packages/ptpython/entry_points/run_ptpython.py", line 62, in run
    no_colors=no_colors, startup_paths=startup_paths)
  File "/Library/Python/2.7/site-packages/ptpython/repl.py", line 204, in embed
    repl.start_repl(startup_paths=startup_paths)
  File "/Library/Python/2.7/site-packages/ptpython/repl.py", line 43, in start_repl
    self._execute_startup(startup_paths)
  File "/Library/Python/2.7/site-packages/ptpython/repl.py", line 101, in _execute_startup
    with open(path, 'r') as f:
IOError: [Errno 2] No such file or directory: '/Users/dongweiming/.pythonstartup'
```