### PR TITLE
remove unicode_literals from repl.py

### DIFF
--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -10,8 +10,6 @@ Utility for creating a Python repl.
 # Warning: don't import `print_function` from __future__, otherwise we will
 #          also get the print_function inside `eval` on Python 2.7.
 
-from __future__ import unicode_literals
-
 from pygments import highlight
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.lexers import PythonTracebackLexer


### PR DESCRIPTION
i think `unicode_literals` is not a good choice.  for example:

```python
$ cat test.py
# coding=utf-8
fname = u'包包'.encode('utf-8')
sql = 'select id, pid from xx where name in (%s)' 
sql = sql % ','.join(["'%s'" % name for name in [fname]])
$ptpython --interactive=test.py   

Traceback (most recent call last):
  File "/usr/local/bin/ptpython", line 9, in <module>
    load_entry_point('ptpython==0.4', 'console_scripts', 'ptpython')()
  File "build/bdist.linux-x86_64/egg/ptpython/entry_points/run_ptpython.py", line 62, in run
  File "build/bdist.linux-x86_64/egg/ptpython/repl.py", line 210, in embed
  File "build/bdist.linux-x86_64/egg/ptpython/repl.py", line 45, in start_repl
  File "build/bdist.linux-x86_64/egg/ptpython/repl.py", line 106, in _execute_startup
  File "/usr/local/lib/python2.7/dist-packages/six.py", line 672, in exec_
    exec("""exec _code_ in _globs_, _locs_""")
  File "<string>", line 1, in <module>
  File "test.py", line 4, in <module>
    sql = sql % ','.join(["'%s'" % name for name in [fname]])
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
```

but use ipython is ok.:

```python
/usr/local/bin/ipython -i test.py
Python 2.7.3 (default, Apr 10 2013, 06:20:15) 
Type "copyright", "credits" or "license" for more information.

IPython 2.3.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: sql
Out[1]: "select id, pid from xx where name in ('\xe5\x8c\x85\xe5\x8c\x85')"
```

[http://python-future.org/unicode_literals.html](http://python-future.org/unicode_literals.html). i against `unicode_literals` too. #13 maybe cause this.