### PR TITLE
Closes issue #55

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -6,7 +6,6 @@ Copy this file to ~/.ptpython/config.py
 from __future__ import unicode_literals
 from prompt_toolkit.keys import Keys
 from pygments.token import Token
-from ptpython.layout import CompletionVisualisation
 
 __all__ = (
     'configure',
@@ -20,52 +19,52 @@ def configure(repl):
     :param repl: `PythonRepl` instance.
     """
     # Show function signature (bool).
-    repl.show_signature = True
+    repl.settings.show_signature = True
 
     # Show docstring (bool).
-    repl.show_docstring = False
+    repl.settings.show_docstring = False
 
     # Show the "[Meta+Enter] Execute" message when pressing [Enter] only
     # inserts a newline instead of executing the code.
-    repl.show_meta_enter_message = True
+    repl.settings.show_meta_enter_message = True
 
     # Show completions. (NONE, POP_UP, MULTI_COLUMN or TOOLBAR)
-    repl.completion_visualisation = CompletionVisualisation.POP_UP
+    repl.settings.completion_visualisation = 'CompletionVisualisation.POP_UP'
 
     # When CompletionVisualisation.POP_UP has been chosen, use this
     # scroll_offset in the completion menu.
-    repl.completion_menu_scroll_offset = 0
+    repl.settings.completion_menu_scroll_offset = 0
 
     # Show line numbers (when the input contains multiple lines.)
-    repl.show_line_numbers = True
+    repl.settings.show_line_numbers = True
 
     # Show status bar.
-    repl.show_status_bar = True
+    repl.settings.show_status_bar = True
 
     # When the sidebar is visible, also show the help text.
-    repl.show_sidebar_help = True
+    repl.settings.show_sidebar_help = True
 
     # Highlight matching parethesis.
-    repl.highlight_matching_parenthesis = True
+    repl.settings.highlight_matching_parenthesis = True
 
     # Line wrapping. (Instead of horizontal scrolling.)
-    repl.wrap_lines = True
+    repl.settings.wrap_lines = True
 
     # Mouse support.
-    repl.enable_mouse_support = True
+    repl.settings.enable_mouse_support = True
 
     # Complete while typing. (Don't require tab before the
     # completion menu is shown.)
-    repl.complete_while_typing = True
+    repl.settings.complete_while_typing = True
 
     # Vi mode.
-    repl.vi_mode = False
+    repl.settings.vi_mode = False
 
     # Paste mode. (When True, don't insert whitespace after new line.)
-    repl.paste_mode = False
+    repl.settings.paste_mode = False
 
     # Use the classic prompt. (Display '>>>' instead of 'In [1]'.)
-    repl.prompt_style = 'classic'  # 'classic' or 'ipython'
+    repl.settings.prompt_style = 'classic'  # 'classic' or 'ipython'
 
     # History Search.
     # When True, going back in history will filter the history on the records
@@ -73,26 +72,26 @@ def configure(repl):
     # Note: When enable, please disable the `complete_while_typing` option.
     #       otherwise, when there is a completion available, the arrows will
     #       browse through the available completions instead of the history.
-    repl.enable_history_search = False
+    repl.settings.enable_history_search = False
 
     # Enable auto suggestions. (Pressing right arrow will complete the input,
     # based on the history.)
-    repl.enable_auto_suggest = False
+    repl.settings.enable_auto_suggest = False
 
     # Enable open-in-editor. Pressing C-X C-E in emacs mode or 'v' in
     # Vi navigation mode will open the input in the current editor.
-    repl.enable_open_in_editor = True
+    repl.settings.enable_open_in_editor = True
 
     # Enable system prompt. Pressing meta-! will display the system prompt.
     # Also enables Control-Z suspend.
-    repl.enable_system_bindings = True
+    repl.settings.enable_system_bindings = True
 
     # Ask for confirmation on exit.
-    repl.confirm_exit = True
+    repl.settings.confirm_exit = True
 
     # Enable input validation. (Don't try to execute when the input contains
     # syntax errors.)
-    repl.enable_input_validation = True
+    repl.settings.enable_input_validation = True
 
     # Use this colorscheme for the code.
     repl.use_code_colorscheme('pastie')

--- a/examples/python-embed-with-custom-prompt.py
+++ b/examples/python-embed-with-custom-prompt.py
@@ -31,7 +31,7 @@ def configure(repl):
             ]
 
     repl.all_prompt_styles['custom'] = CustomPrompt()
-    repl.prompt_style = 'custom'
+    repl.settings.prompt_style = 'custom'
 
     # 2. Assign a new callable to `get_input_prompt_tokens`. This will always take effect.
     ## repl.get_input_prompt_tokens = lambda cli: [(Token.In, '[hello] >>> ')]

--- a/ptpython/config.py
+++ b/ptpython/config.py
@@ -10,6 +10,30 @@ from six.moves.configparser import ConfigParser
 
 option_re = re.compile('^(?P<option>\w+)\s+=.+(?P<comment>#.*)?$')
 
+dynamic_settings = ['show_signature',
+                    'show_docstring',
+                    'show_meta_enter_message',
+                    'completion_visualisation',
+                    'completion_menu_scroll_offset',
+                    'show_line_numbers',
+                    'show_status_bar',
+                    'wrap_lines',
+                    'complete_while_typing',
+                    'vi_mode', 'paste_mode',
+                    'confirm_exit',
+                    'accept_input_on_enter',
+                    'enable_open_in_editor',
+                    'enable_system_bindings',
+                    'enable_input_validation',
+                    'enable_auto_suggest',
+                    'enable_mouse_support',
+                    'enable_history_search',
+                    'highlight_matching_parenthesis',
+                    'show_sidebar',
+                    'show_sidebar_help',
+                    'terminal_title',
+                    'exit_message',
+                    'prompt_style']
 
 class Settings:
     """
@@ -60,16 +84,18 @@ class Settings:
                 self.user_defined[key] = ptpycfg.get(key, '')
     
     def __getattr__(self, name):
-        if name in self.user_defined:
+        if name in dynamic_settings and name in self.user_defined:
             return self.user_defined[name]
         else:
-            raise AttributeError()
+            raise AttributeError("setting '%s' is not supported" % name)
 
     def __setattr__(self, name, value):
         if name == 'user_defined':
             super(Settings, self).__setattr__(name, value)
-        else:
+        elif name in dynamic_settings:
             self.user_defined[name] = value
+        else:
+            raise AttributeError("setting '%s' is not supported" % name)
 
     def __dir__(self):
         dirlist = super(Settings, self).__dir__()

--- a/ptpython/config.py
+++ b/ptpython/config.py
@@ -5,7 +5,7 @@ import copy
 import os
 import re
 import six
-from configparser import ConfigParser
+from six.moves.configparser import ConfigParser
 
 
 option_re = re.compile('^(?P<option>\w+)\s+=.+(?P<comment>#.*)?$')

--- a/ptpython/config.py
+++ b/ptpython/config.py
@@ -1,0 +1,83 @@
+"""
+Ptpython settings loader from config file.
+"""
+import re
+from configparser import ConfigParser
+
+
+option_re = re.compile('^(?P<option>\w+)\s+=.+(?P<comment>#.*)?$')
+
+
+class Settings:
+    user_defined = {}
+    file_path = None
+
+    def __init__(self, defaults=None):
+        if defaults:
+            for k, v in defaults.items():
+                self.user_defined[k] = v
+    
+    def update_from(self, file_path):
+        self.file_path = file_path
+        cfg_parser = ConfigParser(inline_comment_prefixes=('#',))
+        cfg_parser.read(self.file_path)
+        ptpycfg = cfg_parser['ptpython']
+        converters = [ConfigParser.getboolean,
+                      ConfigParser.getint,
+                      ConfigParser.getfloat]
+        for key in ptpycfg:
+            converted = False
+            for func in converters:
+                try:
+                    value = func(cfg_parser, 'ptpython', key)
+                except ValueError:
+                    continue
+                else:
+                    self.user_defined[key] = value
+                    converted = True
+                    break
+            if not converted:
+                self.user_defined[key] = ptpycfg.get(key, '')
+    
+    def __getattr__(self, name):
+        if name in self.user_defined:
+            return self.user_defined[name]
+        else:
+            raise AttributeError()
+
+    def __setattr__(self, name, value):
+        if name in ['user_defined', 'file_path']:
+            super(Settings, self).__setattr__(name, value)
+        else:
+            self.user_defined[name] = value
+
+    def __dir__(self):
+        dirlist = super(Settings, self).__dir__()
+        dirlist.extend(self.user_defined.keys())
+        dirlist.sort()
+        return dirlist
+
+    def save_config(self):
+        # ConfigParser write method doesn't preserve comments.
+        # This is a rudimentary replacement to keep them that
+        # works only for this very specific, one section based,
+        # config file.
+        with open(self.file_path, 'r') as f:
+            lines = f.readlines()
+        cfg_file = open(self.file_path, 'w')
+        for line in lines:
+            if line[0] in ['#', '[', '\n']:
+                cfg_file.write(line)
+            elif line[0].isalpha():
+                match = option_re.search(line)
+                if match:
+                    key = match.group('option')
+                    cmt = match.group('comment')
+                    if cmt:
+                        newline = '%s = %s # %s\n' % (
+                            key, str(self.user_defined[key]), cmt)
+                    else:
+                        newline = '%s = %s\n' % (
+                            key, str(self.user_defined[key]))
+                    cfg_file.write(newline)
+        cfg_file.close()

--- a/ptpython/config.py
+++ b/ptpython/config.py
@@ -17,9 +17,8 @@ class Settings:
 
     :param defaults: dictionary with repl's settings customisable in conf.cfg.
     """
-    user_defined = {}
-
     def __init__(self, defaults=None):
+        self.user_defined = {}
         if defaults:
             for k, v in defaults.items():
                 self.user_defined[k] = v
@@ -101,29 +100,27 @@ class Settings:
             with open(file_path, 'r') as f:
                 current_lines = f.readlines()
 
-        cfg_file = open(file_path, 'w')
-        for line in current_lines:
-            if line[0] in ['#', '[', '\n']:
-                cfg_file.write(line)
-            elif line[0].isalpha():
-                match = option_re.search(line)
-                if match:
-                    key = match.group('option')
-                    cmt = match.group('comment')
-                    if cmt:
-                        newline = '%s = %s # %s\n' % (key, str(settings.pop(key)), cmt)
-                    else:
-                        newline = '%s = %s\n' % (key, str(settings.pop(key)))
-                    cfg_file.write(newline)
+        with open(file_path, 'w') as cfg_file:
+            for line in current_lines:
+                if line[0] in ['#', '[', '\n']:
+                    cfg_file.write(line)
+                elif line[0].isalpha():
+                    match = option_re.search(line)
+                    if match:
+                        key = match.group('option')
+                        cmt = match.group('comment')
+                        if cmt:
+                            newline = '%s = %s # %s\n' % (key, str(settings.pop(key)), cmt)
+                        else:
+                            newline = '%s = %s\n' % (key, str(settings.pop(key)))
+                        cfg_file.write(newline)
 
-        if len(current_lines) == 0:
-            # The conf.cfg file didn't exit before. The first line of the
-            # file must be the section name between brackets.
-            cfg_file.write('[ptpython]\n')
+            if len(current_lines) == 0:
+                # The conf.cfg file didn't exit before. The first line of the
+                # file must be the section name between brackets.
+                cfg_file.write('[ptpython]\n')
 
-        # Write down the rest of the settings.
-        for k, v in settings.items():
-            newline = "%s = %s\n" % (k, str(v))
-            cfg_file.write(newline)
-
-        cfg_file.close()
+            # Write down the rest of the settings.
+            for k, v in settings.items():
+                newline = "%s = %s\n" % (k, str(v))
+                cfg_file.write(newline)

--- a/ptpython/contrib/asyncssh_repl.py
+++ b/ptpython/contrib/asyncssh_repl.py
@@ -48,8 +48,8 @@ class ReplSSHServerSession(asyncssh.SSHServerSession):
         # Disable open-in-editor and system prompt. Because it would run and
         # display these commands on the server side, rather than in the SSH
         # client.
-        repl.enable_open_in_editor = False
-        repl.enable_system_bindings = False
+        repl.settings.enable_open_in_editor = False
+        repl.settings.enable_system_bindings = False
 
         # PipInput object, for sending input in the CLI.
         # (This is something that we can use in the prompt_toolkit event loop,

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -67,9 +67,16 @@ def run():
             if os.path.exists(path):
                 run_config(repl, path)
 
+        # Save user settings in config file when repl is done
+        def done(repl):
+            path = os.path.join(config_dir, 'conf.cfg')
+            # Create the file if it doesn't exist
+            repl.settings.save_config(path)
+
         embed(vi_mode=vi_mode,
               history_filename=os.path.join(config_dir, 'history'),
               configure=configure,
+              done=done,
               startup_paths=startup_paths,
               title='Python REPL (ptpython)')
 

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -22,7 +22,8 @@ import os
 import six
 import sys
 
-from ptpython.repl import embed, enable_deprecation_warnings, run_config
+from ptpython.repl import (embed, enable_deprecation_warnings,
+                           load_config, run_config)
 
 
 def run():
@@ -59,6 +60,9 @@ def run():
 
         # Apply config file
         def configure(repl):
+            path = os.path.join(config_dir, 'conf.cfg')
+            if os.path.exists(path):
+                load_config(repl, path)
             path = os.path.join(config_dir, 'config.py')
             if os.path.exists(path):
                 run_config(repl, path)

--- a/ptpython/filters.py
+++ b/ptpython/filters.py
@@ -24,14 +24,14 @@ class HasSignature(PythonInputFilter):
 
 class ShowSidebar(PythonInputFilter):
     def __call__(self, cli):
-        return self.python_input.show_sidebar
+        return self.python_input.settings.show_sidebar
 
 
 class ShowSignature(PythonInputFilter):
     def __call__(self, cli):
-        return self.python_input.show_signature
+        return self.python_input.settings.show_signature
 
 
 class ShowDocstring(PythonInputFilter):
     def __call__(self, cli):
-        return self.python_input.show_docstring
+        return self.python_input.settings.show_docstring

--- a/ptpython/history_browser.py
+++ b/ptpython/history_browser.py
@@ -404,7 +404,7 @@ def create_key_bindings(python_input, history_mapping):
     """
     manager = KeyBindingManager(
         enable_search=True,
-        enable_vi_mode=Condition(lambda cli: python_input.vi_mode),
+        enable_vi_mode=Condition(lambda cli: python_input.settings.vi_mode),
         enable_extra_page_navigation=True,
         vi_state=python_input.key_bindings_manager.vi_state)
     handle = manager.registry.add_binding
@@ -501,7 +501,7 @@ def create_key_bindings(python_input, history_mapping):
         " Cancel and go back. "
         event.cli.set_return_value(None)
 
-    enable_system_bindings = Condition(lambda cli: python_input.enable_system_bindings)
+    enable_system_bindings = Condition(lambda cli: python_input.settings.enable_system_bindings)
 
     @handle(Keys.ControlZ, filter=enable_system_bindings)
     def _(event):
@@ -580,7 +580,7 @@ def create_history_application(python_input, original_document):
         },
         initial_focussed_buffer=HISTORY_BUFFER,
         style=python_input._current_style,
-        mouse_support=Condition(lambda cli: python_input.enable_mouse_support),
+        mouse_support=Condition(lambda cli: python_input.settings.enable_mouse_support),
         key_bindings_registry=create_key_bindings(python_input, history_mapping)
     )
     return application

--- a/ptpython/ipython.py
+++ b/ptpython/ipython.py
@@ -195,7 +195,7 @@ class InteractiveShellEmbed(_InteractiveShellEmbed):
             history_filename=history_filename)
 
         if title:
-            ipython_input.terminal_title = title
+            ipython_input.settings.terminal_title = title
 
         if configure:
             configure(ipython_input)

--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -36,10 +36,10 @@ def load_python_bindings(key_bindings_manager, python_input):
     """
     Custom key bindings.
     """
-    sidebar_visible = Condition(lambda cli: python_input.show_sidebar)
+    sidebar_visible = Condition(lambda cli: python_input.settings.show_sidebar)
     handle = key_bindings_manager.registry.add_binding
     has_selection = HasSelection()
-    vi_mode_enabled = Condition(lambda cli: python_input.vi_mode)
+    vi_mode_enabled = Condition(lambda cli: python_input.settings.vi_mode)
 
     @handle(Keys.ControlL)
     def _(event):
@@ -53,7 +53,7 @@ def load_python_bindings(key_bindings_manager, python_input):
         """
         Show/hide sidebar.
         """
-        python_input.show_sidebar = not python_input.show_sidebar
+        python_input.settings.show_sidebar = not python_input.settings.show_sidebar
 
     @handle(Keys.F3)
     def _(event):
@@ -76,14 +76,14 @@ def load_python_bindings(key_bindings_manager, python_input):
         """
         Toggle between Vi and Emacs mode.
         """
-        python_input.vi_mode = not python_input.vi_mode
+        python_input.settings.vi_mode = not python_input.settings.vi_mode
 
     @handle(Keys.F6)
     def _(event):
         """
         Enable/Disable paste mode.
         """
-        python_input.paste_mode = not python_input.paste_mode
+        python_input.settings.paste_mode = not python_input.settings.paste_mode
 
     @handle(Keys.Tab, filter= ~sidebar_visible & ~has_selection & TabShouldInsertWhitespaceFilter())
     def _(event):
@@ -104,7 +104,7 @@ def load_python_bindings(key_bindings_manager, python_input):
         (When not in Vi navigaton mode, and when multiline is enabled.)
         """
         b = event.current_buffer
-        empty_lines_required = python_input.accept_input_on_enter or 10000
+        empty_lines_required = python_input.settings.accept_input_on_enter or 10000
 
         def at_the_end(b):
             """ we consider the cursor at the end when there is no text after
@@ -112,7 +112,7 @@ def load_python_bindings(key_bindings_manager, python_input):
             text = b.document.text_after_cursor
             return text == '' or (text.isspace() and not '\n' in text)
 
-        if python_input.paste_mode:
+        if python_input.settings.paste_mode:
             # In paste mode, always insert text.
             b.insert_text('\n')
 
@@ -130,8 +130,8 @@ def load_python_bindings(key_bindings_manager, python_input):
             auto_newline(b)
 
     @handle(Keys.ControlD, filter=~sidebar_visible & Condition(lambda cli:
-            # Only when the `confirm_exit` flag is set.
-            python_input.confirm_exit and
+            # Only when the `settings.confirm_exit` flag is set.
+            python_input.settings.confirm_exit and
             # And the current buffer is empty.
             cli.current_buffer_name == DEFAULT_BUFFER and
             not cli.current_buffer.text))
@@ -139,7 +139,7 @@ def load_python_bindings(key_bindings_manager, python_input):
         """
         Override Control-D exit, to ask for confirmation.
         """
-        python_input.show_exit_confirmation = True
+        python_input.settings.show_exit_confirmation = True
 
 
 def load_sidebar_bindings(key_bindings_manager, python_input):
@@ -147,7 +147,7 @@ def load_sidebar_bindings(key_bindings_manager, python_input):
     Load bindings for the navigation in the sidebar.
     """
     handle = key_bindings_manager.registry.add_binding
-    sidebar_visible = Condition(lambda cli: python_input.show_sidebar)
+    sidebar_visible = Condition(lambda cli: python_input.settings.show_sidebar)
 
     @handle(Keys.Up, filter=sidebar_visible)
     @handle(Keys.ControlP, filter=sidebar_visible)
@@ -187,7 +187,7 @@ def load_sidebar_bindings(key_bindings_manager, python_input):
     @handle(Keys.Escape, filter=sidebar_visible)
     def _(event):
         " Hide sidebar. "
-        python_input.show_sidebar = False
+        python_input.settings.show_sidebar = False
 
 
 def load_confirm_exit_bindings(key_bindings_manager, python_input):
@@ -195,7 +195,7 @@ def load_confirm_exit_bindings(key_bindings_manager, python_input):
     Handle yes/no key presses when the exit confirmation is shown.
     """
     handle = key_bindings_manager.registry.add_binding
-    confirmation_visible = Condition(lambda cli: python_input.show_exit_confirmation)
+    confirmation_visible = Condition(lambda cli: python_input.settings.show_exit_confirmation)
 
     @handle('y', filter=confirmation_visible)
     @handle('Y', filter=confirmation_visible)
@@ -211,7 +211,7 @@ def load_confirm_exit_bindings(key_bindings_manager, python_input):
         """
         Cancel exit.
         """
-        python_input.show_exit_confirmation = False
+        python_input.settings.show_exit_confirmation = False
 
 
 def auto_newline(buffer):

--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -139,7 +139,7 @@ def load_python_bindings(key_bindings_manager, python_input):
         """
         Override Control-D exit, to ask for confirmation.
         """
-        python_input.settings.show_exit_confirmation = True
+        python_input.show_exit_confirmation = True
 
 
 def load_sidebar_bindings(key_bindings_manager, python_input):
@@ -195,7 +195,7 @@ def load_confirm_exit_bindings(key_bindings_manager, python_input):
     Handle yes/no key presses when the exit confirmation is shown.
     """
     handle = key_bindings_manager.registry.add_binding
-    confirmation_visible = Condition(lambda cli: python_input.settings.show_exit_confirmation)
+    confirmation_visible = Condition(lambda cli: python_input.show_exit_confirmation)
 
     @handle('y', filter=confirmation_visible)
     @handle('Y', filter=confirmation_visible)
@@ -211,7 +211,7 @@ def load_confirm_exit_bindings(key_bindings_manager, python_input):
         """
         Cancel exit.
         """
-        python_input.settings.show_exit_confirmation = False
+        python_input.show_exit_confirmation = False
 
 
 def auto_newline(buffer):

--- a/ptpython/layout.py
+++ b/ptpython/layout.py
@@ -320,7 +320,7 @@ def status_bar(key_bindings_manager, python_input):
         default_char=Char(token=TB),
         filter=~IsDone() & RendererHeightIsKnown() &
             Condition(lambda cli: python_input.settings.show_status_bar and
-                                  not python_input.settings.show_exit_confirmation))
+                                  not python_input.show_exit_confirmation))
 
 
 def get_inputmode_tokens(cli, python_input):
@@ -391,7 +391,7 @@ def show_sidebar_button_info(python_input):
             width=LayoutDimension.exact(width)),
         filter=~IsDone() & RendererHeightIsKnown() &
             Condition(lambda cli: python_input.settings.show_status_bar and
-                                  not python_input.settings.show_exit_confirmation))
+                                  not python_input.show_exit_confirmation))
 
 
 def exit_confirmation(python_input, token=Token.ExitConfirmation):
@@ -406,7 +406,7 @@ def exit_confirmation(python_input, token=Token.ExitConfirmation):
             (token, '  \n'),
         ]
 
-    visible = ~IsDone() & Condition(lambda cli: python_input.settings.show_exit_confirmation)
+    visible = ~IsDone() & Condition(lambda cli: python_input.show_exit_confirmation)
 
     return ConditionalContainer(
         content=Window(TokenListControl(
@@ -491,7 +491,7 @@ def create_layout(python_input, key_bindings_manager,
             scroll_offsets=ScrollOffsets(bottom=1, left=4, right=4),
             # As long as we're editing, prefer a minimal height of 6.
             get_height=(lambda cli: (
-                None if cli.is_done or python_input.settings.show_exit_confirmation
+                None if cli.is_done or python_input.show_exit_confirmation
                         else input_buffer_height)),
         )
 

--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -22,6 +22,7 @@ from prompt_toolkit.utils import Callback, is_windows
 from prompt_toolkit.validation import ConditionalValidator
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, ConditionalAutoSuggest
 
+from ptpython.config import Settings
 from ptpython.completer import PythonCompleter
 from ptpython.key_bindings import load_python_bindings, load_sidebar_bindings, load_confirm_exit_bindings
 from ptpython.layout import create_layout, CompletionVisualisation
@@ -153,40 +154,42 @@ class PythonInput(object):
         self._extra_buffer_processors = _extra_buffer_processors or []
 
         # Settings.
-        self.show_signature = True
-        self.show_docstring = False
-        self.show_meta_enter_message = True
-        self.completion_visualisation = CompletionVisualisation.MULTI_COLUMN
-        self.completion_menu_scroll_offset = 1
-
-        self.show_line_numbers = False
-        self.show_status_bar = True
-        self.wrap_lines = True
-        self.complete_while_typing = True
-        self.vi_mode = vi_mode
-        self.paste_mode = False  # When True, don't insert whitespace after newline.
-        self.confirm_exit = True  # Ask for confirmation when Control-D is pressed.
-        self.accept_input_on_enter = 2  # Accept when pressing Enter 'n' times.
-                                        # 'None' means that meta-enter is always required.
-        self.enable_open_in_editor = True
-        self.enable_system_bindings = True
-        self.enable_input_validation = True
-        self.enable_auto_suggest = False
-        self.enable_mouse_support = False
-        self.enable_history_search = False  # When True, like readline, going
-                                            # back in history will filter the
-                                            # history on the records starting
-                                            # with the current input.
-
-        self.highlight_matching_parenthesis = True
-        self.show_sidebar = False  # Currently show the sidebar.
-        self.show_sidebar_help = True # When the sidebar is visible, also show the help text.
-        self.show_exit_confirmation = False  # Currently show 'Do you really want to exit?'
-        self.terminal_title = None  # The title to be displayed in the terminal. (None or string.)
-        self.exit_message = 'Do you really want to exit?'
-
-        # Tokens to be shown at the prompt.
-        self.prompt_style = 'classic'  # The currently active style.
+        self.settings = Settings({
+            'show_signature': True,
+            'show_docstring': False,
+            'show_meta_enter_message': True,
+            'completion_visualisation': 'CompletionVisualisation.MULTI_COLUMN',
+            'completion_menu_scroll_offset': 1,
+            
+            'show_line_numbers': False,
+            'show_status_bar': True,
+            'wrap_lines': True,
+            'complete_while_typing': True,
+            'vi_mode': vi_mode,
+            'paste_mode': False,  # When True, don't insert whitespace after newline.
+            'confirm_exit': True,  # Ask for confirmation when Control-D is pressed.
+            'accept_input_on_enter': 2,  # Accept when pressing Enter 'n' times.
+                                         # 'None' means that meta-enter is always required.
+            'enable_open_in_editor': True,
+            'enable_system_bindings': True,
+            'enable_input_validation': True,
+            'enable_auto_suggest': False,
+            'enable_mouse_support': False,
+            'enable_history_search': False,  # When True, like readline, going
+                                             # back in history will filter the
+                                             # history on the records starting
+                                             # with the current input.
+            
+            'highlight_matching_parenthesis': True,
+            'show_sidebar': False,  # Currently show the sidebar.
+            'show_sidebar_help': True, # When the sidebar is visible, also show the help text.
+            'show_exit_confirmation': False,  # Currently show 'Do you really want to exit?'
+            'terminal_title': None,  # The title to be displayed in the terminal. (None or string.)
+            'exit_message': 'Do you really want to exit?',
+            
+            # Tokens to be shown at the prompt.
+            'prompt_style': 'classic'  # The currently active style.
+        })
 
         self.all_prompt_styles = {  # Styles selectable from the menu.
             'ipython': IPythonPrompt(self),
@@ -194,10 +197,10 @@ class PythonInput(object):
         }
 
         self.get_input_prompt_tokens = lambda cli: \
-            self.all_prompt_styles[self.prompt_style].in_tokens(cli)
+            self.all_prompt_styles[self.settings.prompt_style].in_tokens(cli)
 
         self.get_output_prompt_tokens = lambda cli: \
-            self.all_prompt_styles[self.prompt_style].out_tokens(cli)
+            self.all_prompt_styles[self.settings.prompt_style].out_tokens(cli)
 
         #: Load styles.
         self.code_styles = get_all_code_styles()
@@ -224,14 +227,14 @@ class PythonInput(object):
         self.key_bindings_manager = KeyBindingManager(
             enable_abort_and_exit_bindings=True,
             enable_search=True,
-            enable_vi_mode=Condition(lambda cli: self.vi_mode),
-            enable_open_in_editor=Condition(lambda cli: self.enable_open_in_editor),
-            enable_system_bindings=Condition(lambda cli: self.enable_system_bindings),
-            enable_auto_suggest_bindings=Condition(lambda cli: self.enable_auto_suggest),
+            enable_vi_mode=Condition(lambda cli: self.settings.vi_mode),
+            enable_open_in_editor=Condition(lambda cli: self.settings.enable_open_in_editor),
+            enable_system_bindings=Condition(lambda cli: self.settings.enable_system_bindings),
+            enable_auto_suggest_bindings=Condition(lambda cli: self.settings.enable_auto_suggest),
 
             # Disable all default key bindings when the sidebar or the exit confirmation
             # are shown.
-            enable_all=Condition(lambda cli: not (self.show_sidebar or self.show_exit_confirmation)))
+            enable_all=Condition(lambda cli: not (self.settings.show_sidebar or self.settings.show_exit_confirmation)))
 
         load_python_bindings(self.key_bindings_manager, self)
         load_sidebar_bindings(self.key_bindings_manager, self)
@@ -288,7 +291,7 @@ class PythonInput(object):
                 ...
         """
         # Extra key bindings should not be active when the sidebar is visible.
-        sidebar_visible = Condition(lambda cli: self.show_sidebar)
+        sidebar_visible = Condition(lambda cli: self.settings.show_sidebar)
 
         def add_binding_decorator(*keys, **kw):
             # Pop default filter keyword argument.
@@ -348,21 +351,24 @@ class PythonInput(object):
         Create a list of `Option` instances for the options sidebar.
         """
         def enable(attribute, value=True):
-            setattr(self, attribute, value)
+            setattr(self.settings, attribute, value)
 
             # Return `True`, to be able to chain this in the lambdas below.
             return True
 
         def disable(attribute):
-            setattr(self, attribute, False)
+            setattr(self.settings, attribute, False)
             return True
 
+        def load(object):
+            pass
+        
         def simple_option(title, description, field_name, values=None):
             " Create Simple on/of option. "
             values = values or ['off', 'on']
 
             def get_current_value():
-                return values[bool(getattr(self, field_name))]
+                return values[bool(getattr(self.settings, field_name))]
 
             def get_values():
                 return {
@@ -386,7 +392,7 @@ class PythonInput(object):
                 Option(title='Complete while typing',
                        description="Generate autocompletions automatically while typing. "
                                    'Don\'t require pressing TAB. (Not compatible with "History search".)',
-                       get_current_value=lambda: ['off', 'on'][self.complete_while_typing],
+                       get_current_value=lambda: ['off', 'on'][self.settings.complete_while_typing],
                        get_values=lambda: {
                            'on': lambda: enable('complete_while_typing') and disable('enable_history_search'),
                            'off': lambda: disable('complete_while_typing'),
@@ -394,7 +400,7 @@ class PythonInput(object):
                 Option(title='History search',
                        description='When pressing the up-arrow, filter the history on input starting '
                                    'with the current text. (Not compatible with "Complete while typing".)',
-                       get_current_value=lambda: ['off', 'on'][self.enable_history_search],
+                       get_current_value=lambda: ['off', 'on'][self.settings.enable_history_search],
                        get_values=lambda: {
                            'on': lambda: enable('enable_history_search') and disable('complete_while_typing'),
                            'off': lambda: disable('enable_history_search'),
@@ -417,7 +423,7 @@ class PythonInput(object):
                 Option(title='Accept input on enter',
                        description='Amount of ENTER presses required to execute input when the cursor '
                                    'is at the end of the input. (Note that META+ENTER will always execute.)',
-                       get_current_value=lambda: str(self.accept_input_on_enter or 'meta-enter'),
+                       get_current_value=lambda: str(self.settings.accept_input_on_enter or 'meta-enter'),
                        get_values=lambda: {
                            '2': lambda: enable('accept_input_on_enter', 2),
                            '3': lambda: enable('accept_input_on_enter', 3),
@@ -428,7 +434,8 @@ class PythonInput(object):
             OptionCategory('Display', [
                 Option(title='Completions',
                        description='Visualisation to use for displaying the completions. (Multiple columns, one column, a toolbar or nothing.)',
-                       get_current_value=lambda: self.completion_visualisation,
+                       get_current_value=lambda: getattr(globals()[self.settings.completion_visualisation.split('.')[0]],
+                                                         self.settings.completion_visualisation.split('.')[1]),
                        get_values=lambda: {
                            CompletionVisualisation.NONE: lambda: enable('completion_visualisation', CompletionVisualisation.NONE),
                            CompletionVisualisation.POP_UP: lambda: enable('completion_visualisation', CompletionVisualisation.POP_UP),
@@ -437,7 +444,7 @@ class PythonInput(object):
                        }),
                 Option(title='Prompt',
                        description="Visualisation of the prompt. ('>>>' or 'In [1]:')",
-                       get_current_value=lambda: self.prompt_style,
+                       get_current_value=lambda: self.settings.prompt_style,
                        get_values=lambda: dict((s, partial(enable, 'prompt_style', s)) for s in self.all_prompt_styles)),
                 simple_option(title='Show signature',
                               description='Display function signatures.',
@@ -502,12 +509,12 @@ class PythonInput(object):
             buffer=self._create_buffer(),
             buffers=buffers,
             key_bindings_registry=self.key_bindings_registry,
-            paste_mode=Condition(lambda cli: self.paste_mode),
-            mouse_support=Condition(lambda cli: self.enable_mouse_support),
+            paste_mode=Condition(lambda cli: self.settings.paste_mode),
+            mouse_support=Condition(lambda cli: self.settings.enable_mouse_support),
             on_abort=AbortAction.RETRY,
             on_exit=self._on_exit,
             get_style=lambda: self._current_style,
-            get_title=lambda: self.terminal_title,
+            get_title=lambda: self.settings.terminal_title,
             on_start=self._on_start,
             on_input_timeout=Callback(self._on_input_timeout))
 
@@ -516,23 +523,23 @@ class PythonInput(object):
         Create the `Buffer` for the Python input.
         """
         def is_buffer_multiline():
-            return (self.paste_mode or
-                    self.accept_input_on_enter is None or
+            return (self.settings.paste_mode or
+                    self.settings.accept_input_on_enter is None or
                     document_is_multiline_python(python_buffer.document))
 
         python_buffer = Buffer(
             is_multiline=Condition(is_buffer_multiline),
-            complete_while_typing=Condition(lambda: self.complete_while_typing),
-            enable_history_search=Condition(lambda: self.enable_history_search),
+            complete_while_typing=Condition(lambda: self.settings.complete_while_typing),
+            enable_history_search=Condition(lambda: self.settings.enable_history_search),
             tempfile_suffix='.py',
             history=self.history,
             completer=self._completer,
             validator=ConditionalValidator(
                 self._validator,
-                Condition(lambda: self.enable_input_validation)),
+                Condition(lambda: self.settings.enable_input_validation)),
             auto_suggest=ConditionalAutoSuggest(
                 AutoSuggestFromHistory(),
-                Condition(lambda cli: self.enable_auto_suggest)),
+                Condition(lambda cli: self.settings.enable_auto_suggest)),
             accept_action=self._accept_action)
 
         return python_buffer

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -44,8 +44,7 @@ class PythonRepl(PythonInput):
             '_accept_action': AcceptAction.run_in_terminal(
                 handler=self._process_document, render_cli_done=True),
             '_on_start': Callback(self._on_start),
-            # '_on_exit': AbortAction.RETURN_NONE,
-            '_on_exit': Callback(self._on_exit),
+            '_on_exit': AbortAction.RETURN_NONE,
         })
 
         super(PythonRepl, self).__init__(*a, **kw)
@@ -64,10 +63,6 @@ class PythonRepl(PythonInput):
                     output = self.cli.output
                     output.write('WARNING | File not found: {}\n\n'.format(path))
 
-    def _on_exit(self):
-        import pdb; pdb.set_trace()
-        self.settings.save_config()
-                    
     def _process_document(self, cli, buffer):
         line = buffer.text
 
@@ -205,6 +200,19 @@ def enable_deprecation_warnings():
 
 
 def load_config(repl, config_file='~/.ptpython/conf.cfg'):
+    """
+    Load REPL user settings from config file.
+
+    :param repl: `PythonInput` instance.
+    :param config_file: Path of the .cfg user settings file.
+    """
+    assert isinstance(repl, PythonInput)
+    assert isinstance(config_file, six.text_type)
+
+    # Expand tildes.
+    config_file = os.path.expanduser(config_file)
+
+    # Load the settings from the file
     repl.settings.update_from(config_file)
 
     
@@ -248,7 +256,7 @@ def run_config(repl, config_file='~/.ptpython/config.py'):
          enter_to_continue()
 
 
-def embed(globals=None, locals=None, configure=None,
+def embed(globals=None, locals=None, configure=None, done=None,
           vi_mode=False, history_filename=None, title=None,
           startup_paths=None, patch_stdout=False, return_asyncio_coroutine=False):
     """
@@ -313,3 +321,6 @@ def embed(globals=None, locals=None, configure=None,
     else:
         with patch_context:
             cli.run()
+
+    if done:
+        done(repl)


### PR DESCRIPTION
Allows the user to save the sidebar settings in a `conf.cfg` file inside the `<conf_dir>`.

Provides a new class `Settings` that is used as an attribute of the `PythonInput` class. All the user customisable settings are provided in a dictionary in the constructor of the class `Settings`. Changing the settings has the same effect as in the current code. 

The `Settings` class provides two utility methods:
- `update_from`: that loads customisable settings from the `~/.ptpython/conf.cfg` (or another given path).
- `save_config`: that saves the settings in the `~/.ptpython/conf.cfg` file (or another given path).

I added a `done` parameter to the `embed`. The idea is to have a way to do something upon client termination. The utility of the `done` hook in this PR is to be able to save the settings to the file. 
