### PR TITLE
Support user_ns arg for compatibility with start_ipython

### DIFF
--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -20,7 +20,7 @@ import six
 import sys
 
 
-def run():
+def run(user_ns=None):
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
@@ -55,7 +55,8 @@ def run():
         # Create an empty namespace for this interactive shell. (If we don't do
         # that, all the variables from this function will become available in
         # the IPython shell.)
-        user_ns = {}
+        if user_ns is None:
+            user_ns = {}
 
         # Startup path
         startup_paths = []


### PR DESCRIPTION
I want to replace `IPython.start_ipython` with `ptpython.entry_points.run_ptipython.run`, but I need to specify `user_ns` which currently is only supported by `start_ipython`.
