### PR TITLE
Eliminate extra validation after two newlines.

### DIFF
--- a/ptpython/key_bindings.py
+++ b/ptpython/key_bindings.py
@@ -105,14 +105,13 @@ def load_python_bindings(key_bindings_manager, python_input):
 
         elif at_the_end(b) and b.document.text.replace(' ', '').endswith(
                     '\n' * (empty_lines_required - 1)):
-            if b.validate():
-                # When the cursor is at the end, and we have an empty line:
-                # drop the empty lines, but return the value.
-                b.document = Document(
-                    text=b.text.rstrip(),
-                    cursor_position=len(b.text.rstrip()))
+            # When the cursor is at the end, and we have an empty line:
+            # drop the empty lines, but return the value.
+            b.document = Document(
+                text=b.text.rstrip(),
+                cursor_position=len(b.text.rstrip()))
 
-                b.accept_action.validate_and_handle(event.cli, b)
+            b.accept_action.validate_and_handle(event.cli, b)
         else:
             auto_newline(b)
 


### PR DESCRIPTION
Even after [the latest python-prompt-toolkit
commit](https://github.com/jonathanslenders/python-prompt-toolkit/commit/43a52365cc99ceb71c5f7bc815525d03140d75fd)
validation occurs twice here, because rstripping the buffer resets the
`validation_state`. I don't see any behavioral differences from dropping
the initial validation altogether.