### PR TITLE
Fix logic error when checking existance of config_dir

### DIFF
--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -27,7 +27,7 @@ def run():
     config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython'))
 
     # Create config directory.
-    if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
+    if not os.path.isdir(config_dir) and not os.path.islink(config_dir):
         os.mkdir(config_dir)
 
     # If IPython is not available, show message and exit here with error status


### PR DESCRIPTION
There is an inconsistence between two entry scripts `run_ptipython.py` and `run_ptpython.py` when checking the existence of `config_dir`. 

In `entry_points/run_ptipython.py`
```
if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
        os.mkdir(config_dir)
```

In `entry_points/run_ptpython.py`
```
if not os.path.isdir(config_dir) and not os.path.islink(config_dir):
        os.mkdir(config_dir)
```

I think it should be an `and` but not an `or`. If the `config_dir` exists, the script fails to start.