### PR TITLE
Use __main__.__dict__ for both globals and locals when running ptpython

### DIFF
--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -69,6 +69,7 @@ def run():
               history_filename=os.path.join(config_dir, 'history'),
               configure=configure,
               locals=__main__.__dict__,
+              globals=__main__.__dict__,
               startup_paths=startup_paths,
               title='Python REPL (ptpython)')
 


### PR DESCRIPTION
Apologies for missing this in my last PR. Insufficient testing on my part.

This fixes the following case:
```>>>a = 3
>>> a = 3
>>> def print_a():
...     print a
>>> print_a()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in print_a
NameError: global name 'a' is not defined
```