### PR TITLE
Use Python3Lexer for python 3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+0.38: 2017-03-28
+----------------
+
+Fixes:
+- Fixed bug in run_ptipython. (It could fail to start if the config directory
+  already existed.)
+
+
 0.38: 2017-03-26
 ----------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.38: 2017-03-26
+----------------
+
+Fixes:
+- Fixed syntax error in run_ptipython script.
+
+
 0.37: 2017-03-26
 ----------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,28 @@
 CHANGELOG
 =========
 
+0.37: 2017-03-26
+----------------
+
+Fixes:
+- Display 'VISUAL BLOCK' and 'INSERT' when we're in these modes.
+- Handle ValueError in PythonValidator. Python2 raises ValueError if the input
+  contains an invalid escape sequence.
+- Use load_key_bindings instead of KeyBindingsManager. (For the latest
+  prompt_toolkit.)
+- Set 'reverse_vi_search_direction'. (Search backwards when '/' was pressed in
+  Vi mode.)
+- Check for symlink when creating config dir.
+- Make default config dir filepath OS independent.
+- Remove minor python version in entry point.
+- Fixed .ptpython directory creation in run_ptpython.
+
+New features:
+- Also accept Ctrl-D for quitting the 'exit confirmation' dialog.
+
+Requires prompt_toolkit 1.0.14.
+
+
 0.36: 2016-10-16
 ----------------
 

--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -147,6 +147,10 @@ class PythonCompleter(Completer):
                     # Jedi issue: "IOError: No such file or directory."
                     # https://github.com/jonathanslenders/ptpython/issues/71
                     pass
+                except AssertionError:
+                    # In jedi.parser.__init__.py: 227, in remove_last_newline,
+                    # the assertion "newline.value.endswith('\n')" can fail.
+                    pass
                 else:
                     for c in completions:
                         yield Completion(c.name_with_symbols, len(c.complete) - len(c.name_with_symbols),

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -27,7 +27,7 @@ def run():
     config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
 
     # Create config directory.
-    if not os.path.isdir(config_dir):
+    if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
         os.mkdir(config_dir)
 
     # If IPython is not available, show message and exit here with error status

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -24,7 +24,7 @@ def run():
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
-    config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython')
+    config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython'))
 
     # Create config directory.
     if not os.path.isdir(config_dir) or not os.path.islink(config_dir):

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -24,7 +24,7 @@ def run():
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
-    config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
+    config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython')
 
     # Create config directory.
     if not os.path.isdir(config_dir) or not os.path.islink(config_dir):

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -27,7 +27,7 @@ def run():
     config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython'))
 
     # Create config directory.
-    if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
+    if not os.path.isdir(config_dir) and not os.path.islink(config_dir):
         os.mkdir(config_dir)
 
     # If IPython is not available, show message and exit here with error status

--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -20,7 +20,7 @@ import six
 import sys
 
 
-def run():
+def run(user_ns=None):
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
@@ -55,7 +55,8 @@ def run():
         # Create an empty namespace for this interactive shell. (If we don't do
         # that, all the variables from this function will become available in
         # the IPython shell.)
-        user_ns = {}
+        if user_ns is None:
+            user_ns = {}
 
         # Startup path
         startup_paths = []

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -29,7 +29,7 @@ def run():
     a = docopt.docopt(__doc__)
 
     vi_mode = bool(a['--vi'])
-    config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
+    config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython'))
 
     # Create config directory.
     if not os.path.isdir(config_dir) or not os.path.islink(config_dir):

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -32,7 +32,7 @@ def run():
     config_dir = os.path.expanduser(a['--config-dir'] or '~/.ptpython/')
 
     # Create config directory.
-    if not os.path.isdir(config_dir):
+    if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
         os.mkdir(config_dir)
 
     # Startup path

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -32,7 +32,7 @@ def run():
     config_dir = os.path.expanduser(a['--config-dir'] or os.path.join('~', '.ptpython'))
 
     # Create config directory.
-    if not os.path.isdir(config_dir) or not os.path.islink(config_dir):
+    if not os.path.isdir(config_dir) and not os.path.islink(config_dir):
         os.mkdir(config_dir)
 
     # Startup path

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -64,9 +64,11 @@ def run():
             if os.path.exists(path):
                 run_config(repl, path)
 
+        import __main__
         embed(vi_mode=vi_mode,
               history_filename=os.path.join(config_dir, 'history'),
               configure=configure,
+              locals=__main__.__dict__,
               startup_paths=startup_paths,
               title='Python REPL (ptpython)')
 

--- a/ptpython/entry_points/run_ptpython.py
+++ b/ptpython/entry_points/run_ptpython.py
@@ -69,6 +69,7 @@ def run():
               history_filename=os.path.join(config_dir, 'history'),
               configure=configure,
               locals=__main__.__dict__,
+              globals=__main__.__dict__,
               startup_paths=startup_paths,
               title='Python REPL (ptpython)')
 

--- a/ptpython/ipython.py
+++ b/ptpython/ipython.py
@@ -28,9 +28,16 @@ from IPython.terminal.ipapp import load_default_config
 from IPython import utils as ipy_utils
 from IPython.core.inputsplitter import IPythonInputSplitter
 
-from pygments.lexers import PythonLexer, BashLexer
+from pygments.lexers import BashLexer
 from pygments.token import Token
 from ptpython.prompt_style import PromptStyle
+
+import six
+
+if six.PY2:
+    from pygments.lexers import PythonLexer
+else:
+    from pygments.lexers import Python3Lexer as PythonLexer
 
 __all__ = (
     'embed',

--- a/ptpython/layout.py
+++ b/ptpython/layout.py
@@ -22,11 +22,16 @@ from prompt_toolkit.selection import SelectionType
 from .filters import HasSignature, ShowSidebar, ShowSignature, ShowDocstring
 from .utils import if_mousedown
 
-from pygments.lexers import PythonLexer
 from pygments.token import Token
 
 import platform
+import six
 import sys
+
+if six.PY2:
+    from pygments.lexers import PythonLexer
+else:
+    from pygments.lexers import Python3Lexer as PythonLexer
 
 __all__ = (
     'create_layout',

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -9,7 +9,7 @@ Utility for creating a Python repl.
 """
 from __future__ import unicode_literals
 
-from pygments.lexers import PythonTracebackLexer, PythonLexer
+from pygments.lexers import PythonTracebackLexer
 from pygments.styles.default import DefaultStyle
 
 from prompt_toolkit.application import AbortAction
@@ -29,6 +29,11 @@ import six
 import sys
 import traceback
 import warnings
+
+if six.PY2:
+    from pygments.lexers import PythonLexer
+else:
+    from pygments.lexers import Python3Lexer as PythonLexer
 
 __all__ = (
     'PythonRepl',

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -15,6 +15,7 @@ from pygments.styles.default import DefaultStyle
 from prompt_toolkit.application import AbortAction
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.interface import AcceptAction
+from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.layout.utils import token_list_width
 from prompt_toolkit.shortcuts import create_asyncio_eventloop
 from prompt_toolkit.styles import style_from_pygments
@@ -85,6 +86,11 @@ class PythonRepl(PythonInput):
             # Append to history and reset.
             cli.search_state.text = ''
             cli.buffers[DEFAULT_BUFFER].reset(append_to_history=True)
+
+        # Make sure that we end up in insert mode.
+        # (Not exactly the right place to check this.)
+        if cli.vi_state.input_mode == InputMode.NAVIGATION:
+            cli.vi_state.input_mode = InputMode.INSERT
 
     def _execute(self, cli, line):
         """

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = open(
 setup(
     name='ptpython',
     author='Jonathan Slenders',
-    version='0.37',
+    version='0.38',
     url='https://github.com/jonathanslenders/ptpython',
     description='Python REPL build on top of prompt_toolkit',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = open(
 setup(
     name='ptpython',
     author='Jonathan Slenders',
-    version='0.38',
+    version='0.39',
     url='https://github.com/jonathanslenders/ptpython',
     description='Python REPL build on top of prompt_toolkit',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             'ptipython%s = ptpython.entry_points.run_ptipython:run' % sys.version_info[0],
         ]
     },
-    extra_require={
+    extras_require={
         'ptipython':  ['ipython'] # For ptipython, we need to have IPython
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = open(
 setup(
     name='ptpython',
     author='Jonathan Slenders',
-    version='0.36',
+    version='0.37',
     url='https://github.com/jonathanslenders/ptpython',
     description='Python REPL build on top of prompt_toolkit',
     long_description=long_description,
@@ -22,7 +22,7 @@ setup(
     install_requires = [
         'docopt',
         'jedi>=0.9.0',
-        'prompt_toolkit>=1.0.0,<2.0.0',
+        'prompt_toolkit>=1.0.14,<2.0.0',
         'pygments',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,7 @@ setup(
             'ptpython = ptpython.entry_points.run_ptpython:run',
             'ptipython = ptpython.entry_points.run_ptipython:run',
             'ptpython%s = ptpython.entry_points.run_ptpython:run' % sys.version_info[0],
-            'ptpython%s.%s = ptpython.entry_points.run_ptpython:run' % sys.version_info[:2],
             'ptipython%s = ptpython.entry_points.run_ptipython:run' % sys.version_info[0],
-            'ptipython%s.%s = ptpython.entry_points.run_ptipython:run' % sys.version_info[:2],
         ]
     },
     extra_require={


### PR DESCRIPTION
If you run `ptipython` with python 3, you'll notice things like `nonlocal` aren't highlighted correctly. This fixes that. 