### PR TITLE
exception handler for django.ImproperlyConfigured

### DIFF
--- a/ptpython/completer.py
+++ b/ptpython/completer.py
@@ -9,6 +9,11 @@ from ptpython.utils import get_jedi_script_from_document
 
 import re
 
+try:
+    import django
+except:
+    pass
+
 __all__ = (
     'PythonCompleter',
 )
@@ -154,6 +159,8 @@ class PythonCompleter(Completer):
                 except SystemError:
                     # File "jedi/api/helpers.py", line 140, in get_stack_at_position
                     # raise SystemError("This really shouldn't happen. There's a bug in Jedi.")
+                    pass
+                except django.core.exceptions.ImproperlyConfigured:
                     pass
                 else:
                     for c in completions:


### PR DESCRIPTION
hi there,

i was trying to use django from the terminal, nevertheless ptpython's autocompletion (before django's configuration) trigs exception raise of django.

just added a quick and dirty exception handling for the case. 

ps: maybe its better to not surpass the exception, since it works if you keep writing "settings.configure()"

== case can be replicated via ==
sudo apt-get install python-django

python2.7 -m ptpython

>> from django.conf import settings

# try to apply settings.configure()
>>> settings.Exception in thread Thread-141:

Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/prompt_toolkit/interface.py", line 836, in run              [F2] Menu - CPython 2.7.12
    completions = list(buffer.completer.get_completions(document, complete_event))
  File "/usr/local/lib/python2.7/dist-packages/ptpython/completer.py", line 127, in get_completions
    completions = script.completions()
  File "/usr/local/lib/python2.7/dist-packages/jedi/api/__init__.py", line 188, in completions
    completion_names = get_completions(user_stmt, b)
  File "/usr/local/lib/python2.7/dist-packages/jedi/api/__init__.py", line 174, in get_completions
    completion_names += self._simple_complete(path, dot, like)
  File "/usr/local/lib/python2.7/dist-packages/jedi/api/__init__.py", line 632, in _simple_complete
    for name in dir(namespace):
  File "/usr/lib/python2.7/dist-packages/django/utils/functional.py", line 225, in inner
    self._setup()
  File "/usr/lib/python2.7/dist-packages/django/conf/__init__.py", line 42, in _setup
    % (desc, ENVIRONMENT_VARIABLE))
ImproperlyConfigured: Requested settings, but settings are not configured. You must either define the environment variable DJANGO_SET.

