### PR TITLE
ptipython: set __file__ when running interactively

### DIFF
--- a/ptpython/entry_points/run_ptipython.py
+++ b/ptpython/entry_points/run_ptipython.py
@@ -72,6 +72,7 @@ def run(user_ns=None):
         for path in startup_paths:
             if os.path.exists(path):
                 with open(path, 'r') as f:
+                    user_ns['__file__'] = path
                     code = compile(f.read(), path, 'exec')
                     six.exec_(code, user_ns, user_ns)
             else:


### PR DESCRIPTION
Python code inspecting __file__ will find what it's looking for, rather than a `NameError: name '__file__' is not defined`

This is the behavior exposed by `python -i` as well as `ipython -i`