### PR TITLE
Fixing isue 103 nd 83, docstring not scrollable in mouse mode. 

### DIFF
--- a/ptpython/python_input.py
+++ b/ptpython/python_input.py
@@ -624,7 +624,7 @@ class PythonInput(object):
                     if not isinstance(string, six.text_type):
                         string = string.decode('utf-8')
                     cli.buffers['docstring'].reset(
-                        initial_document=Document(string, cursor_position=0))
+                        initial_document=Document(string, cursor_position=cli.buffers['docstring'].cursor_position))
                 else:
                     cli.buffers['docstring'].reset()
 


### PR DESCRIPTION
Fixing by setting cursor position on docstring document. Tried locally and it seemed to resolve the issue for me.

It is a simple fix so unlikely that this would affect other modules/aspect of the code.