### PR TITLE
Don't crash history browser with no history and hitting space

### DIFF
--- a/ptpython/history_browser.py
+++ b/ptpython/history_browser.py
@@ -433,6 +433,10 @@ def create_key_bindings(python_input, history_mapping):
         b = event.current_buffer
         line_no = b.document.cursor_position_row
 
+        if not history_mapping.history_lines:
+            # If we've no history, then nothing to do
+            return
+
         if line_no in history_mapping.selected_lines:
             # Remove line.
             history_mapping.selected_lines.remove(line_no)


### PR DESCRIPTION
In the case where there was no history (first startup or deleting ~/.ptpython/history), hitting space would try to add a non-existent line. 

Found myself in the first ten seconds of using ptpython (keyboard mashing to test what looked like a sticky key), but the issue existed already: #214.