### PR TITLE
switch from asyncio.async to asyncio.ensure_future

### DIFF
--- a/examples/asyncio-python-embed.py
+++ b/examples/asyncio-python-embed.py
@@ -45,8 +45,8 @@ def interactive_shell():
 
 
 def main():
-    asyncio.async(print_counter())
-    asyncio.async(interactive_shell())
+    asyncio.ensure_future(print_counter())
+    asyncio.ensure_future(interactive_shell())
 
     loop.run_forever()
     loop.close()

--- a/ptpython/contrib/asyncssh_repl.py
+++ b/ptpython/contrib/asyncssh_repl.py
@@ -92,7 +92,7 @@ class ReplSSHServerSession(asyncssh.SSHServerSession):
         self._chan = chan
 
         # Run REPL interface.
-        f = asyncio.async(self.cli.run_async())
+        f = asyncio.ensure_future(self.cli.run_async())
 
         # Close channel when done.
         def done(_):


### PR DESCRIPTION
Python 3.7 removes asyncio.async (it has been deprecated since 3.4.4).  It was replaced by asyncio.ensure_future.

https://docs.python.org/3.7/whatsnew/3.7.html
https://docs.python.org/3.6/library/asyncio-task.html#asyncio.async