### PR TITLE
Update Jedi dependency; closes #248

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages('.'),
     install_requires = [
         'docopt',
-        'jedi>=0.9.0',
+        'jedi>=0.9.0,<=0.11.1',
         'prompt_toolkit>=2.0.0,<2.1.0',
         'pygments',
     ],


### PR DESCRIPTION
A bug in Jedi (davidhalter/jedi#1148) mutates `sys.path`, breaking module imports. The bug isn’t present in Jedi versions ≤ 0.11.1, so we cap the dependency at 0.11.1.

When Jedi is fixed, we can revisit, but as of 10 days ago (2018-08-09) the bug still seems to be present..