### PR TITLE
Update config.py example to use key_processor

### DIFF
--- a/examples/ptpython_config/config.py
+++ b/examples/ptpython_config/config.py
@@ -141,7 +141,7 @@ def configure(repl):
     @repl.add_key_binding('j', 'j', filter=ViInsertMode())
     def _(event):
         " Map 'jj' to Escape. "
-        event.cli.input_processor.feed(KeyPress(Keys.Escape))
+        event.cli.key_processor.feed(KeyPress(Keys.Escape))
     """
 
     # Custom key binding for some simple autocorrection while typing.


### PR DESCRIPTION
It appears that as of release 2.0.1 on 2018-06-02 the python-prompt-toolkit package was updated so that 
```
  * `input_processor` was renamed to `key_processor`.
```
This config example was updated at the time to import the correct object, but the comment that actually uses it later on was not updated. This simply fixes the comment as well so that people using the most recent version of ptpython can uncomment the config example here and use it.

Tested with a fresh install of ptpython and this config file with lines 141-144 uncommented. I was getting this error when typing 'jj' in Vim insert mode in ptpython:
```
Unhandled exception in event loop:
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/eventloop/posix.py", line 154, in _run_task
    t()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/eventloop/context.py", line 115, in new_func
    return func(*a, **kw)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/application/application.py", line 555, in read_from_input
    self.key_processor.process_keys()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/key_binding/key_processor.py", line 273, in process_keys
    self._process_coroutine.send(key_press)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/key_binding/key_processor.py", line 180, in _process
    self._call_handler(matches[-1], key_sequence=buffer[:])
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/key_binding/key_processor.py", line 323, in _call_handler
    handler.call(event)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/prompt_toolkit/key_binding/key_bindings.py", line 78, in call
    return self.handler(event)
  File "/Users/chris_miller/.ptpython/config.py", line 143, in _
    event.cli.input_processor.feed(KeyPress(Keys.Escape))

Exception 'Application' object has no attribute 'input_processor'
```
After the change proposed here the error went away.